### PR TITLE
Fixed a bug in DS3231 GetTemperature()

### DIFF
--- a/RtcDS3231.h
+++ b/RtcDS3231.h
@@ -531,8 +531,7 @@ public:
         // Read scaled 16-bit 2's complement integer and return degC float	    
         _wire.requestFrom(DS3231_ADDRESS, DS3231_REG_TEMP_SIZE);
         uint8_t mstemp = _wire.read();
-	//                   MSBYTE         LSBYTE    
-        return(  (int16_t)( (mstemp << 8) | (uint8_t)_wire.read() ) / 256.0f  );
+        return (int16_t)((mstemp << 8) | (uint8_t)_wire.read()) / 256.0f;
     }
 
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=RTCtime
-version=1.0.3
+version=1.0.4
 author=smz <tinker@smz.it>
 maintainer=smz (https://github.com/smz)
 sentence=A "Standard C Runtime" compatible library for interfacing the DS1307 and DS3231 Real Time Clock modules.


### PR DESCRIPTION
A bug affecting the DS3231 GetTemperature() method has been fixed, thanks to @mrwgx3.

For more info about this bug see: https://github.com/Makuna/Rtc/issues/49